### PR TITLE
fix: bundling failed in windows environment

### DIFF
--- a/bundler.go
+++ b/bundler.go
@@ -416,6 +416,7 @@ func (b *Bundler) bundle(e ConfigurationEnvironment) (err error) {
 		"GOOS=" + e.OS,
 		"GOPATH=" + os.Getenv("GOPATH"),
 		"PATH=" + os.Getenv("PATH"),
+		"TEMP=" + os.Getenv("TEMP"),
 	}
 
 	// Exec


### PR DESCRIPTION
Fixes bundling failed error when bundling in Windows environment:
    FATA[0003] bundling failed: bundling for environment windows/amd64 failed: building failed:
    mkdir C:\Windows\go-build396406123: Access is denied.
The error appears when it tries to create the temporary building folder inside C:\Windows folder.
It needs to have the TEMP environment variable defined in the bundling context.