### PR TITLE
allow BindData to be called for each configured environment, using conditional compliation flags/filenames

### DIFF
--- a/astilectron-bundler/main.go
+++ b/astilectron-bundler/main.go
@@ -86,9 +86,11 @@ func main() {
 	// Switch on subcommand
 	switch s {
 	case "bd":
-		// Bind data
-		if err = b.BindData(runtime.GOOS, runtime.GOARCH); err != nil {
-			astilog.Fatal(errors.Wrap(err, "binding data failed"))
+		// Bind Data
+		for _, env := range c.Environments {
+			if err = b.BindData(env.OS, env.Arch); err != nil {
+				astilog.Fatal(errors.Wrap(err, "binding data failed for "+env.OS+"/"+env.Arch))
+			}
 		}
 	case "cc":
 		// Clear cache

--- a/astilectron-bundler/main.go
+++ b/astilectron-bundler/main.go
@@ -89,7 +89,7 @@ func main() {
 		// Bind Data
 		for _, env := range c.Environments {
 			if err = b.BindData(env.OS, env.Arch); err != nil {
-				astilog.Fatal(errors.Wrap(err, "binding data failed for "+env.OS+"/"+env.Arch))
+				astilog.Fatal(errors.Wrapf(err, "binding data failed for %s/%s", env.OS, env.Arch))
 			}
 		}
 	case "cc":

--- a/bundler.go
+++ b/bundler.go
@@ -328,7 +328,8 @@ func (b *Bundler) BindData(os, arch string) (err error) {
 		{Path: filepath.Join(b.pathInput, "resources"), Recursive: true},
 		{Path: filepath.Join(b.pathInput, "vendor"), Recursive: true},
 	}
-	c.Output = filepath.Join(b.pathInput, "bind.go")
+	c.Tags = fmt.Sprintf("%s,%s", os, arch)
+	c.Output = filepath.Join(b.pathInput, fmt.Sprintf("bind_%s_%s.go", os, arch))
 	c.Prefix = b.pathInput
 
 	// Bind data


### PR DESCRIPTION
This PR updates the "bd" subcommand with the ability to call BindData on each environment configured (or just the runtime.GOOS/GOARCH combination if no environments are specifically configured).

Each binddata file is named and uses build tags to ensure no collisions between files occur.

This will allow for cross compliation using a single bundler binddata command.