### PR TITLE
Using xgo for cross compiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,32 @@ If no input path is specified, the working directory path is used.
 
 We **strongly** encourage to leave the input path option empty and execute the **bundler** while in the directory of the project you're bundling.
 
+# Using xgo
+To build your app using xgo you should add 
+`"xgo": {
+      "enabled": true,
+      "deps": ["https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2"]
+  }`
+into your `bundler.json`
+
+To install and/or update xgo, simply type:
+`go get -u github.com/karalabe/xgo`
+You can test whether xgo is functioning correctly by requesting it to cross compile itself and verifying that all cross compilations succeeded or not.
+```bash
+$ xgo github.com/karalabe/xgo
+...
+
+$ ls -al
+-rwxr-xr-x  1 root     root      2792436 Sep 14 16:45 xgo-android-21-arm
+-rwxr-xr-x  1 root     root      2353212 Sep 14 16:45 xgo-darwin-386
+-rwxr-xr-x  1 root     root      2906128 Sep 14 16:45 xgo-darwin-amd64
+-rwxr-xr-x  1 root     root      2388288 Sep 14 16:45 xgo-linux-386
+-rwxr-xr-x  1 root     root      2960560 Sep 14 16:45 xgo-linux-amd64
+-rwxr-xr-x  1 root     root      2437864 Sep 14 16:45 xgo-linux-arm
+-rwxr-xr-x  1 root     root      2551808 Sep 14 16:45 xgo-windows-386.exe
+-rwxr-xr-x  1 root     root      3130368 Sep 14 16:45 xgo-windows-amd64.exe
+```
+
 # Usage
 
 If **astilectron-bundler** has been installed properly (and the $GOPATH is in your $PATH), run the following command:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Run the following command:
       }
     }
   ],
+  "xgo": {
+      "enabled": true,
+      "deps": ["https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2"]
+  },
   "icon_path_darwin": "path/to/icon.icns",
   "icon_path_linux": "path/to/icon.png",
   "icon_path_windows": "path/to/icon.ico",

--- a/bundler.go
+++ b/bundler.go
@@ -408,10 +408,11 @@ func (l ldflags) string() string {
 // bundle bundles an os
 func (b *Bundler) bundle(e ConfigurationEnvironment) (err error) {
 	// flag indicates if bundling for current computer os and arch
-	var buildForCurrentMachine bool
+	var buildForCurrentMachine, useXGO bool
 	if runtime.GOOS == e.OS && runtime.GOARCH == e.Arch {
 		buildForCurrentMachine = true
 	}
+	useXGO = buildForCurrentMachine || !b.xgo.Enabled
 
 	// Remove previous environment folder
 	var environmentPath = filepath.Join(b.pathOutput, e.OS+"-"+e.Arch)
@@ -463,7 +464,7 @@ func (b *Bundler) bundle(e ConfigurationEnvironment) (err error) {
 
 	// if we build for current machine or xgo is disabled - use ordinary go build
 	// else use xgo https://github.com/karalabe/xgo
-	if buildForCurrentMachine || !b.xgo.Enabled {
+	if !useXGO {
 		cmd = exec.Command(b.pathGoBinary, "build", "-ldflags", l.string(), "-o", binaryPath, b.pathBuild)
 		cmd.Env = []string{
 			"GOARCH=" + e.Arch,
@@ -492,7 +493,7 @@ func (b *Bundler) bundle(e ConfigurationEnvironment) (err error) {
 		return
 	}
 
-	if !buildForCurrentMachine {
+	if useXGO {
 		// Search for file binary
 		// xgo names output files by himself. The only option we can set is prefix. So we must find file with such prefix
 		var files []os.FileInfo

--- a/bundler.go
+++ b/bundler.go
@@ -13,6 +13,8 @@ import (
 	"syscall"
 	"time"
 
+	"runtime"
+
 	"github.com/akavel/rsrc/rsrc"
 	"github.com/asticode/go-astilectron"
 	"github.com/asticode/go-astilog"
@@ -58,6 +60,9 @@ type Configuration struct {
 	// The path where the vendor directory will be created/used
 	VendorDirPath string `json:"vendor_dir_path"`
 
+	// Configuration for compiling via xgo
+	XGO ConfigurationXGO `json:"xgo"`
+
 	//!\\ DEBUG ONLY
 	AstilectronPath string `json:"astilectron_path"` // when making changes to astilectron
 }
@@ -69,6 +74,12 @@ type ConfigurationEnvironment struct {
 	OS                   string            `json:"os"`
 }
 
+// ConfigurationXGO represents the bundle xgo configuration
+type ConfigurationXGO struct {
+	Enabled bool     `json:"enabled"`
+	Deps    []string `json:"deps"`
+}
+
 // Bundler represents an object capable of bundling an Astilectron app
 type Bundler struct {
 	appName         string
@@ -76,6 +87,7 @@ type Bundler struct {
 	Client          *http.Client
 	ctx             context.Context
 	environments    []ConfigurationEnvironment
+	xgo             ConfigurationXGO
 	pathAstilectron string
 	pathBuild       string
 	pathCache       string
@@ -112,6 +124,7 @@ func New(c *Configuration) (b *Bundler, err error) {
 		appName:      c.AppName,
 		Client:       &http.Client{},
 		environments: c.Environments,
+		xgo:          c.XGO,
 	}
 
 	// Add context
@@ -394,6 +407,12 @@ func (l ldflags) string() string {
 
 // bundle bundles an os
 func (b *Bundler) bundle(e ConfigurationEnvironment) (err error) {
+	// flag indicates if bundling for current computer os and arch
+	var buildForCurrentMachine bool
+	if runtime.GOOS == e.OS && runtime.GOARCH == e.Arch {
+		buildForCurrentMachine = true
+	}
+
 	// Remove previous environment folder
 	var environmentPath = filepath.Join(b.pathOutput, e.OS+"-"+e.Arch)
 	astilog.Debugf("Removing %s", environmentPath)
@@ -438,16 +457,25 @@ func (b *Bundler) bundle(e ConfigurationEnvironment) (err error) {
 
 	// Build cmd
 	astilog.Debugf("Building for os %s and arch %s", e.OS, e.Arch)
-	var binaryPath = filepath.Join(environmentPath, "binary")
-	var cmd = exec.Command(b.pathGoBinary, "build", "-ldflags", l.string(), "-o", binaryPath, b.pathBuild)
-	cmd.Env = []string{
-		"GOARCH=" + e.Arch,
-		"GOOS=" + e.OS,
-		"GOPATH=" + os.Getenv("GOPATH"),
-		"GOROOT=" + os.Getenv("GOROOT"),
-		"PATH=" + os.Getenv("PATH"),
-		"TEMP=" + os.Getenv("TEMP"),
-		"TAGS=" + os.Getenv("TAGS"),
+	var binaryName = "binary"
+	var binaryPath = filepath.Join(environmentPath, binaryName)
+	var cmd *exec.Cmd
+
+	// if we build for current machine or xgo is disabled - use ordinary go build
+	// else use xgo https://github.com/karalabe/xgo
+	if buildForCurrentMachine || !b.xgo.Enabled {
+		cmd = exec.Command(b.pathGoBinary, "build", "-ldflags", l.string(), "-o", binaryPath, b.pathBuild)
+		cmd.Env = []string{
+			"GOARCH=" + e.Arch,
+			"GOOS=" + e.OS,
+			"GOPATH=" + os.Getenv("GOPATH"),
+			"GOROOT=" + os.Getenv("GOROOT"),
+			"PATH=" + os.Getenv("PATH"),
+			"TEMP=" + os.Getenv("TEMP"),
+			"TAGS=" + os.Getenv("TAGS"),
+		}
+	} else {
+		cmd = exec.Command("xgo", "--deps", strings.Join(b.xgo.Deps, " "), "--targets", e.OS+"/"+e.Arch, "--dest", environmentPath, "--out", binaryName, "-ldflags", l.string(), b.pathInput)
 	}
 
 	if e.EnvironmentVariables != nil {
@@ -462,6 +490,23 @@ func (b *Bundler) bundle(e ConfigurationEnvironment) (err error) {
 	if o, err = cmd.CombinedOutput(); err != nil {
 		err = errors.Wrapf(err, "building failed: %s", o)
 		return
+	}
+
+	if !buildForCurrentMachine {
+		// Search for file binary
+		// xgo names output files by himself. The only option we can set is prefix. So we must find file with such prefix
+		var files []os.FileInfo
+		files, err = ioutil.ReadDir(environmentPath)
+		if err != nil {
+			err = errors.Wrapf(err, "unable to find binary: %s", binaryName)
+			return
+		}
+		for _, f := range files {
+			if strings.HasPrefix(f.Name(), binaryName) {
+				binaryPath = filepath.Join(environmentPath, f.Name())
+				break
+			}
+		}
 	}
 
 	// Finish bundle based on OS


### PR DESCRIPTION
This PR for https://github.com/asticode/go-astilectron-bundler/issues/17
To build your app using xgo you should add 
`"xgo": {
      "enabled": true,
      "deps": ["https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2"]
  }`
into your `bundler.json`

To install and/or update xgo, simply type:
`go get -u github.com/karalabe/xgo`
You can test whether xgo is functioning correctly by requesting it to cross compile itself and verifying that all cross compilations succeeded or not.
```bash
$ xgo github.com/karalabe/xgo
...

$ ls -al
-rwxr-xr-x  1 root     root      2792436 Sep 14 16:45 xgo-android-21-arm
-rwxr-xr-x  1 root     root      2353212 Sep 14 16:45 xgo-darwin-386
-rwxr-xr-x  1 root     root      2906128 Sep 14 16:45 xgo-darwin-amd64
-rwxr-xr-x  1 root     root      2388288 Sep 14 16:45 xgo-linux-386
-rwxr-xr-x  1 root     root      2960560 Sep 14 16:45 xgo-linux-amd64
-rwxr-xr-x  1 root     root      2437864 Sep 14 16:45 xgo-linux-arm
-rwxr-xr-x  1 root     root      2551808 Sep 14 16:45 xgo-windows-386.exe
-rwxr-xr-x  1 root     root      3130368 Sep 14 16:45 xgo-windows-amd64.exe
```