### PR TITLE
CFBundlePackageType added to Info.plist

### DIFF
--- a/bundler.go
+++ b/bundler.go
@@ -645,6 +645,8 @@ func (b *Bundler) finishDarwin(environmentPath, binaryPath string) (err error) {
 		<string>com.`+b.appName+`</string>
 		<key>LSUIElement</key>
 		<string>`+lsuiElement+`</string>
+		<key>CFBundlePackageType</key>
+		<string>APPL</string>
 	</dict>
 </plist>`), 0777); err != nil {
 		err = errors.Wrapf(err, "adding Info.plist to %s failed", fp)


### PR DESCRIPTION
I have no idea what is it for (figured out using trial and error method), but I can't validate and start apps without `CFBundlePackageType` element.