### PR TITLE
Allow resourceadapter to be run in another directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can execute custom actions on your resources before binding them to the bina
 }
 ```
 
-All paths must be relative to the `resources` folder.
+All paths must be relative to the `resources` folder. You can also add a `cwd` to each adapter to specify the directory you want, it's also relative to `resources`.
 
 ## Custom paths
 

--- a/astilectron-bundler/main.go
+++ b/astilectron-bundler/main.go
@@ -7,10 +7,10 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/asticode/go-astilectron-bundler"
 	"github.com/asticode/go-astilog"
 	"github.com/asticode/go-astitools/flag"
 	"github.com/pkg/errors"
+	"github.com/yukuan1988/go-astilectron-bundler"
 )
 
 // Flags

--- a/bundler.go
+++ b/bundler.go
@@ -85,6 +85,7 @@ type ConfigurationEnvironment struct {
 type ConfigurationResourcesAdapter struct {
 	Args []string `json:"args"`
 	Name string   `json:"name"`
+	Cwd  string   `json:"cwd"`
 }
 
 // Bundler represents an object capable of bundling an Astilectron app
@@ -543,9 +544,12 @@ func (b *Bundler) adaptResources() (err error) {
 		// Create cmd
 		cmd := exec.CommandContext(b.ctx, a.Name, a.Args...)
 		cmd.Dir = o
+		if a.Cwd != "" {
+			cmd.Dir = filepath.Join(o, a.Cwd)
+		}
 
 		// Run
-		astilog.Debugf("Running %s", strings.Join(cmd.Args, " "))
+		astilog.Debugf("Running %s in directory %s", strings.Join(cmd.Args, " "), cmd.Dir)
 		var b []byte
 		if b, err = cmd.CombinedOutput(); err != nil {
 			err = errors.Wrapf(err, "running %s failed with output %s", strings.Join(cmd.Args, " "), b)


### PR DESCRIPTION
I need to remove node_modules folder since I have webpack and I need to install react back since it's not webpacked. `npm` doesn't have option to specify a target directory so a `cwd` makes it work. There might be other commands with the same problem.

You may need to skip the main.go since I pointed it to my fork.

Simon