### PR TITLE
Pass GOFLAGS through to new environment

### DIFF
--- a/bundler.go
+++ b/bundler.go
@@ -347,6 +347,7 @@ func (b *Bundler) bundle(e ConfigurationEnvironment) (err error) {
 		"GOARCH=" + e.Arch,
 		"GOOS=" + e.OS,
 		"GOCACHE=" + os.Getenv("GOCACHE"),
+		"GOFLAGS=" + os.Getenv("GOFLAGS"),
 		"GOPATH=" + gp,
 		"GOROOT=" + os.Getenv("GOROOT"),
 		"PATH=" + os.Getenv("PATH"),


### PR DESCRIPTION
This allows, for example, enabling the race detection with GOFLAGS=-race