### PR TITLE
Info.plist generation from the bundler configuration file property

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,29 @@ You can use the `bind` attribute to alter the bind configuration like so:
 }
 ```
 
+## Info.plist generation from the bundler configuration file property
+You can add custom **Info.plist** configuration to the **bundler.json**:
+```json
+{
+  "app_name": "Best App",
+  "icon_path_darwin": "resources/icon.icns",
+  "info_plist": {
+    "CFBundlePackageType": "APPL",
+    "CFBundleInfoDictionaryVersion": "6.0",
+    "CFBundleIconFile": "icon.icns",
+    "CFBundleDisplayName": "Best App",
+    "CFBundleExecutable": "app_binary",
+    "CFBundleIdentifier": "com.company.BestApp",
+    "LSUIElement": "NO",
+    "LSMinimumSystemVersion": "10.11",
+    "NSHighResolutionCapable": true,
+    "NSAppTransportSecurity": {
+      "NSAllowsArbitraryLoads": true
+    }
+  }
+}
+```
+
 # Usage
 
 If **astilectron-bundler** has been installed properly (and the $GOPATH is in your $PATH), run the following command:

--- a/bundler.go
+++ b/bundler.go
@@ -681,7 +681,10 @@ func (b *Bundler) finishDarwin(environmentPath, binaryPath string) (err error) {
 	astilog.Debugf("Adding Info.plist to %s", fp)
 
 	if infoPlist != nil {
-		return plister.Generate(fp, infoPlist)
+		if err = plister.Generate(fp, infoPlist); err != nil {
+			err = errors.Wrap(err, "generating Info.plist failed")
+		}
+		return
 	}
 
 	lsuiElement := "NO"


### PR DESCRIPTION
I needed to have different **Info.plist** files for several programs. And I decided to put the configuration for **Info.plist** into the bundler configuration file (**bundler.json**).