### PR TITLE
Added double quotes before and after ldflags values in the String method

### DIFF
--- a/bundler.go
+++ b/bundler.go
@@ -356,8 +356,8 @@ func (b *Bundler) bundle(e ConfigurationEnvironment) (err error) {
 
 	std := LDFlags{
 		"X": []string{
-			`"main.AppName=` + b.appName + `"`,
-			`"main.BuiltAt=` + time.Now().String() + `"`,
+			`main.AppName=` + b.appName,
+			`main.BuiltAt=` + time.Now().String(),
 		},
 	}
 	if e.OS == "windows" {

--- a/ldflags.go
+++ b/ldflags.go
@@ -24,7 +24,7 @@ func (l LDFlags) String() string {
 			continue
 		}
 		for _, s := range ss {
-			o = append(o, fmt.Sprintf(`-%s %s`, k, s))
+			o = append(o, fmt.Sprintf(`-%s "%s"`, k, s))
 		}
 	}
 	return strings.Join(o, " ")


### PR DESCRIPTION
When I add ldflags via the command line, they are not quoted.