### PR TITLE
Add Bind Data Package Path Property

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,30 @@
+# Go Astilectron Bundler
+
 This package provides a way to bundle an [astilectron](https://github.com/asticode/go-astilectron) app using the [bootstrap](https://github.com/asticode/go-astilectron-bootstrap).
 
 Check out the [demo](https://github.com/asticode/go-astilectron-demo) to see a working example.
 
-# Installation
+## Installation
 
 Run the following command:
 
-    $ go get -u github.com/asticode/go-astilectron-bundler/...
+```shell
+go get -u github.com/asticode/go-astilectron-bundler/...
+```
 
-# Build the binary
-    
+## Build the binary
+
 Run the following command:
 
-    $ go install github.com/asticode/go-astilectron-bundler/astilectron-bundler
-    
-# Configuration
+```shell
+go install github.com/asticode/go-astilectron-bundler/astilectron-bundler
+```
+
+## Configuration
 
 **astilectron-bundler** uses a configuration file to know what it's supposed to do.
- 
-## Basic configuration
+
+### Basic configuration
 
 Here's the basic configuration you'll usually need:
 
@@ -33,14 +39,14 @@ Here's the basic configuration you'll usually need:
 
 It will process the project located in the current directory and bundle it in the `output` dir for your os/arch.
 
-## Bundle for specific Astilectron and/or Electron versions
+### Bundle for specific Astilectron and/or Electron versions
 
 The following customization can be made to `bundler.json`
 
-   * version_electron - version of electron, defaults to the value specified in the `go-astilectron` version you're using
-   * version_astilectron - version of astilectron, defaults to the value specified in the `go-astilectron` version you're using
+* `version_electron` - version of electron, defaults to the value specified in the `go-astilectron` version you're using
+* `version_astilectron` - version of astilectron, defaults to the value specified in the `go-astilectron` version you're using
 
-## Bundle for other environments
+### Bundle for other environments
 
 You can bundle your project for multiple environments with the `environments` key:
 
@@ -64,7 +70,7 @@ You can bundle your project for multiple environments with the `environments` ke
 
 For each environment you can specify environment variables with the `env` key.
 
-## Adapt resources
+### Adapt resources
 
 You can execute custom actions on your resources before binding them to the binary such as uglifying the `.js` files with the `resources_adapters` key:
 
@@ -85,9 +91,10 @@ You can execute custom actions on your resources before binding them to the bina
 
 All paths must be relative to the `resources` folder except if you provide a `dir` option (a path relative to the `resources` folder) in which case it will be relative to that path.
 
-## Build flags
+### Build flags
 
 You can pass arbitrary build flags into the build command with the `build_flags` key:
+
 ```json
 {
   "build_flags": {
@@ -96,18 +103,18 @@ You can pass arbitrary build flags into the build command with the `build_flags`
 }
 ```
 
-## Custom paths
+### Custom paths
 
 You can set the following paths:
 
-- `input_path`: path to your project. defaults to the current directory
-- `go_binary_path`: path to the `go` binary. defaults to "go"
-- `output_path`: path to the dir where you'll find the bundle results. defaults to `current directory/output`
-- `resources_path`: path where the `resources` dir is and will be written. path must be relative to the `input_path`. defaults to "resources"
-- `vendor_dir_path`: path where the `vendor` dir will be written. path must be relative to the `output_path`
-- `working_directory_path`: path to the dir where the bundler runs its operations such as provisioning the vendor files or binding data to the binary
+* `input_path`: path to your project. defaults to the current directory
+* `go_binary_path`: path to the `go` binary. defaults to "go"
+* `output_path`: path to the dir where you'll find the bundle results. defaults to `current directory/output`
+* `resources_path`: path where the `resources` dir is and will be written. path must be relative to the `input_path`. defaults to "resources"
+* `vendor_dir_path`: path where the `vendor` dir will be written. path must be relative to the `output_path`
+* `working_directory_path`: path to the dir where the bundler runs its operations such as provisioning the vendor files or binding data to the binary
 
-## Adapt the bind configuration
+### Adapt the bind configuration
 
 You can use the `bind` attribute to alter the bind configuration like so:
 
@@ -115,13 +122,22 @@ You can use the `bind` attribute to alter the bind configuration like so:
 {
   "bind": {
     "output_path": "path/to/bind/output/path",
-    "package": "mypkg"
+    "package": "mypkg",
+    "package_path": "some/module/path/mypkg"
   }
 }
 ```
 
-## Info.plist generation from the bundler configuration file property
+* `output_path`: path to the directory where you want bind files to be created. defaults to the current working directory
+* `package`: the package name to use for the bind files. defaults to "main"
+* `package_path`: the package name used for the `ldflags` set by this library. defaults to the `package` value
+
+When you specify an `output_path`, the `package` and `package_path` will **probably** need to be set.
+
+### Info.plist generation from the bundler configuration file property
+
 You can add custom **Info.plist** configuration to the **bundler.json**:
+
 ```json
 {
   "app_name": "Best App",
@@ -143,26 +159,32 @@ You can add custom **Info.plist** configuration to the **bundler.json**:
 }
 ```
 
-# Usage
+## Usage
 
 If **astilectron-bundler** has been installed properly (and the $GOPATH is in your $PATH), run the following command:
 
-    $ astilectron-bundler -c <path to your configuration file>
-    
+```shell
+astilectron-bundler -c <path to your configuration file>
+```
+
 or if your working directory is your project directory and your bundler configuration has the proper name (`bundler.json`)
 
-    $ astilectron-bundler
-    
-# Output
+```shell
+astilectron-bundler
+```
 
-For each environment you specify in your configuration file, **astilectron-bundler** will create a folder `<output path you specified in the configuration file>/<os>-<arch>` that will contain the proper files.
+## Output
 
-# Ldflags
+For each environment you specify in your configuration file, **astilectron-bundler** will create a folder `<output_path you specified in the configuration file>/<os>-<arch>` that will contain the proper files.
 
-**astilectron-bundler** uses `ldflags` when building the project. It means if you add one of the following variables as global exported variables in your project, they will have the following value:
+## Ldflags
 
-- `AppName`:  filled with the configuration app name
-- `BuiltAt`: filled with the date the build has been done at
+**astilectron-bundler** uses `ldflags` when building the project. It means if you add one of the following variables as global exported variables in your project (in the Bind `package`), they will have the following value:
+
+* `AppName`:  filled with the configuration app name
+* `BuiltAt`: filled with the date the build has been done at
+* `VersionAstilectron`: filled with the version of Astilectron being bundled/used
+* `VersionElectron`: filled the version of Electron being bundled/used
 
 If you need to add more flags yourself, like for a version number, add something
 like this to your `astilectron-bundler` command: `-ldflags X:main.Version=xyzzy`.
@@ -170,29 +192,37 @@ like this to your `astilectron-bundler` command: `-ldflags X:main.Version=xyzzy`
 If you need to add multiple flags you can pass `-ldflags` multiple times, with
 multiple values split on commas, like this:
 
-`-ldflags X:main.Version=xyzzy,main.CommitCount=100 -ldflags race`
+```shell
+-ldflags X:main.Version=xyzzy,main.CommitCount=100 -ldflags race
+```
 
 That would set two variables and enable the race detection.
 
-# Commands
-## Only bind data: bd
+## Commands
+
+### Only bind data: bd
 
 Use this command if you want to skip most of the bundling process and only bind data/generate the `bind.go` file (useful when you want to test your app running `go run *.go`):
 
-    $ astilectron-bundler bd -c <path to your configuration file>
+```shell
+astilectron-bundler bd -c <path to your configuration file>
+```
 
-## Clear the cache: cc
+### Clear the cache: cc
 
 The **bundler** stores downloaded files in a cache to avoid downloading them over and over again. That cache may be corrupted. In that case, use this command to clear the cache:
 
-    $ astilectron-bundler cc
-    
-# Frequent problems
-## "xxx architecture of input file `xxx' is incompatible with xxx output"
+```shell
+astilectron-bundler cc
+```
+
+## Frequent problems
+
+### "xxx architecture of input file `xxx' is incompatible with xxx output"
 
 When building for `linux` you may face an error looking like this:
 
-```
+```shell
 FATA[0009] bundling failed: bundling for environment linux/amd64 failed: building failed: # github.com/asticode/go-astilectron-demo
 /usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
 /usr/bin/ld: i386 architecture of input file `/tmp/go-link-275377070/000000.o' is incompatible with i386:x86-64 output

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-# Go Astilectron Bundler
-
 This package provides a way to bundle an [astilectron](https://github.com/asticode/go-astilectron) app using the [bootstrap](https://github.com/asticode/go-astilectron-bootstrap).
 
 Check out the [demo](https://github.com/asticode/go-astilectron-demo) to see a working example.
 
-## Installation
+# Installation
 
 Run the following command:
 
@@ -12,7 +10,7 @@ Run the following command:
 go get -u github.com/asticode/go-astilectron-bundler/...
 ```
 
-## Build the binary
+# Build the binary
 
 Run the following command:
 
@@ -20,11 +18,11 @@ Run the following command:
 go install github.com/asticode/go-astilectron-bundler/astilectron-bundler
 ```
 
-## Configuration
+# Configuration
 
 **astilectron-bundler** uses a configuration file to know what it's supposed to do.
 
-### Basic configuration
+## Basic configuration
 
 Here's the basic configuration you'll usually need:
 
@@ -39,14 +37,14 @@ Here's the basic configuration you'll usually need:
 
 It will process the project located in the current directory and bundle it in the `output` dir for your os/arch.
 
-### Bundle for specific Astilectron and/or Electron versions
+## Bundle for specific Astilectron and/or Electron versions
 
 The following customization can be made to `bundler.json`
 
 * `version_electron` - version of electron, defaults to the value specified in the `go-astilectron` version you're using
 * `version_astilectron` - version of astilectron, defaults to the value specified in the `go-astilectron` version you're using
 
-### Bundle for other environments
+## Bundle for other environments
 
 You can bundle your project for multiple environments with the `environments` key:
 
@@ -70,7 +68,7 @@ You can bundle your project for multiple environments with the `environments` ke
 
 For each environment you can specify environment variables with the `env` key.
 
-### Adapt resources
+## Adapt resources
 
 You can execute custom actions on your resources before binding them to the binary such as uglifying the `.js` files with the `resources_adapters` key:
 
@@ -91,7 +89,7 @@ You can execute custom actions on your resources before binding them to the bina
 
 All paths must be relative to the `resources` folder except if you provide a `dir` option (a path relative to the `resources` folder) in which case it will be relative to that path.
 
-### Build flags
+## Build flags
 
 You can pass arbitrary build flags into the build command with the `build_flags` key:
 
@@ -103,7 +101,7 @@ You can pass arbitrary build flags into the build command with the `build_flags`
 }
 ```
 
-### Custom paths
+## Custom paths
 
 You can set the following paths:
 
@@ -114,7 +112,7 @@ You can set the following paths:
 * `vendor_dir_path`: path where the `vendor` dir will be written. path must be relative to the `output_path`
 * `working_directory_path`: path to the dir where the bundler runs its operations such as provisioning the vendor files or binding data to the binary
 
-### Adapt the bind configuration
+## Adapt the bind configuration
 
 You can use the `bind` attribute to alter the bind configuration like so:
 
@@ -122,19 +120,17 @@ You can use the `bind` attribute to alter the bind configuration like so:
 {
   "bind": {
     "output_path": "path/to/bind/output/path",
-    "package": "mypkg",
-    "package_path": "some/module/path/mypkg"
+    "package": "mypkg"
   }
 }
 ```
 
 * `output_path`: path to the directory where you want bind files to be created. defaults to the current working directory
 * `package`: the package name to use for the bind files. defaults to "main"
-* `package_path`: the package name used for the `ldflags` set by this library. defaults to the `package` value
 
-When you specify an `output_path`, the `package` and `package_path` will **probably** need to be set.
+When you specify an `output_path`, the `package` will **probably** need to be set.
 
-### Info.plist generation from the bundler configuration file property
+## Info.plist generation from the bundler configuration file property
 
 You can add custom **Info.plist** configuration to the **bundler.json**:
 
@@ -159,7 +155,7 @@ You can add custom **Info.plist** configuration to the **bundler.json**:
 }
 ```
 
-## Usage
+# Usage
 
 If **astilectron-bundler** has been installed properly (and the $GOPATH is in your $PATH), run the following command:
 
@@ -177,14 +173,24 @@ astilectron-bundler
 
 For each environment you specify in your configuration file, **astilectron-bundler** will create a folder `<output_path you specified in the configuration file>/<os>-<arch>` that will contain the proper files.
 
-## Ldflags
+# Ldflags
 
-**astilectron-bundler** uses `ldflags` when building the project. It means if you add one of the following variables as global exported variables in your project (in the Bind `package`), they will have the following value:
+**astilectron-bundler** uses `ldflags` when building the project. It means if you add one of the following variables as global exported variables in your project, they will have the following value:
 
 * `AppName`:  filled with the configuration app name
 * `BuiltAt`: filled with the date the build has been done at
 * `VersionAstilectron`: filled with the version of Astilectron being bundled/used
 * `VersionElectron`: filled the version of Electron being bundled/used
+
+You can use the following to alter the Ldflags behavior:
+
+```json
+{
+  "ldflags_package": "some/path/to/pkg"
+}
+```
+
+* `ldflags_package`: which local package these variables exist in. defaults to `bind`'s `package` value (for backwards compatibility)
 
 If you need to add more flags yourself, like for a version number, add something
 like this to your `astilectron-bundler` command: `-ldflags X:main.Version=xyzzy`.
@@ -198,9 +204,11 @@ multiple values split on commas, like this:
 
 That would set two variables and enable the race detection.
 
-## Commands
+(in either case, make sure to substitute `main` with the package where your `Version`/`CommitCount`/etc. variables exist)
 
-### Only bind data: bd
+# Commands
+
+## Only bind data: bd
 
 Use this command if you want to skip most of the bundling process and only bind data/generate the `bind.go` file (useful when you want to test your app running `go run *.go`):
 
@@ -208,7 +216,7 @@ Use this command if you want to skip most of the bundling process and only bind 
 astilectron-bundler bd -c <path to your configuration file>
 ```
 
-### Clear the cache: cc
+## Clear the cache: cc
 
 The **bundler** stores downloaded files in a cache to avoid downloading them over and over again. That cache may be corrupted. In that case, use this command to clear the cache:
 
@@ -216,9 +224,9 @@ The **bundler** stores downloaded files in a cache to avoid downloading them ove
 astilectron-bundler cc
 ```
 
-## Frequent problems
+# Frequent problems
 
-### "xxx architecture of input file `xxx' is incompatible with xxx output"
+## "xxx architecture of input file `xxx' is incompatible with xxx output"
 
 When building for `linux` you may face an error looking like this:
 


### PR DESCRIPTION
This originated because I had to set the bind data's `output_path` to a subdirectory in my project.

Specifically, I'm setting `output_path` to "bind", so that all `bind_*.go` files go into `./bind/`, and I reference them by importing `github.com/my/module/bind`. This works well, except the `ldflags` that are set by this bundler (`AppName`, `BuiltAt`, etc.) no longer work. This is because the `go build` flags that end up being set are like `-X "bind.AppName=...`. The problem with this is that `go build` doesn't target the `bind` package in the way you'd expect (I'd expect how everything's currently set up to just work).
Apparently, you need to use the full path (I'm not sure of the right name of this) to it, from the root of your project/module. But anyway, I needed the **option** to set the target package used in the `ldflags` different from the actual `package` used for the `bindata` config.
So in the end, this is what the relevant part of my `bundler.json` would look like:
```
{
  "bind": {
    "output_path": "bind",
    "package": "bind",
    "package_path": "github.com/my/module/bind"
  }
}
```

This PR should leave everything working the same as it always has, but adds the ability to set the package used in `ldflags` if you want.

Also, added more info for this bind data stuff to the README, and did some random cleanup.