### PR TITLE
Replaced the default to be the inputpath rather than the CWD '.'

### DIFF
--- a/bundler.go
+++ b/bundler.go
@@ -280,7 +280,11 @@ func New(c *Configuration, l astikit.StdLogger) (b *Bundler, err error) {
 
 	// If build path is empty, ldflags are not set properly
 	if len(b.pathBuild) == 0 {
+		// Keep . as the default incase input_path is not set in the config
 		b.pathBuild = "."
+		if c.InputPath != "" {
+			b.pathBuild = c.InputPath
+		}
 	}
 
 	// Resources path

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
-module github.com/asticode/go-astilectron-bundler
+module github.com/shuttl-io/go-astilectron-bundler
 
 go 1.13
 
 require (
 	github.com/akavel/rsrc v0.8.0
 	github.com/asticode/go-astikit v0.6.0
-	github.com/asticode/go-astilectron v0.16.0
+	github.com/asticode/go-astilectron v0.18.0
+	github.com/asticode/go-astilectron-bundler v0.7.2
 	github.com/asticode/go-bindata v1.0.0
 	github.com/sam-kamerer/go-plister v1.2.0
 	github.com/stretchr/testify v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,11 @@
-module github.com/shuttl-io/go-astilectron-bundler
+module github.com/asticode/go-astilectron-bundler
 
 go 1.13
 
 require (
 	github.com/akavel/rsrc v0.8.0
 	github.com/asticode/go-astikit v0.6.0
-	github.com/asticode/go-astilectron v0.18.0
-	github.com/asticode/go-astilectron-bundler v0.7.2
+	github.com/asticode/go-astilectron v0.16.0
 	github.com/asticode/go-bindata v1.0.0
 	github.com/sam-kamerer/go-plister v1.2.0
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,10 @@ github.com/asticode/go-astikit v0.6.0 h1:zmbw5J2Du8SedBG1I5JjlsS5oG2vHcb6ZzhWMCM
 github.com/asticode/go-astikit v0.6.0/go.mod h1:h4ly7idim1tNhaVkdVBeXQZEE3L0xblP7fCWbgwipF0=
 github.com/asticode/go-astilectron v0.16.0 h1:zBZEoqiFo9pT9xwGZq7GtT2t0gJuDjHoo/pMab1vkXQ=
 github.com/asticode/go-astilectron v0.16.0/go.mod h1:bF7zkk11IwP8lBPhEl3cCtkKIwsRRR6264OFM1v3Yso=
+github.com/asticode/go-astilectron v0.18.0 h1:4Hc069d3/8La+nWt5o/WWYmNiYfzfGGzC1ErAuL2Wq0=
+github.com/asticode/go-astilectron v0.18.0/go.mod h1:bF7zkk11IwP8lBPhEl3cCtkKIwsRRR6264OFM1v3Yso=
+github.com/asticode/go-astilectron-bundler v0.7.2 h1:0/h8rbZyTlywjnG3XGeENe4Pv0/deasZFjkG5iciWBM=
+github.com/asticode/go-astilectron-bundler v0.7.2/go.mod h1:pOhXErxB5yqWhIxWXrXi5GWblxLVUIhZI+wo0xa64CY=
 github.com/asticode/go-bindata v1.0.0 h1:5whO0unjdx2kbAbzoBMS3307jKAEf3oQ1lJcx5RdgA8=
 github.com/asticode/go-bindata v1.0.0/go.mod h1:t/Y+/iCLrvaYkv8Y6PscRnyUeYzy9y9+8JC9CMcKdHY=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=


### PR DESCRIPTION
I need this because I am using go modules outside of the GOPATH and my structure is a little different like so: 

```
/root
  \ cmd
    \ cmd1
      \ main.go
  \ internal
    \gui
      \ ...
bundler.json
```

Being able to tell the bundler to build `./cmd/cmd1` is useful. THe current implementation doesn't take into account `input_path`